### PR TITLE
Mc3 don

### DIFF
--- a/R/logLik_phybreak.R
+++ b/R/logLik_phybreak.R
@@ -207,6 +207,64 @@ lik_coaltimes <- function(phybreakenv) {
   return(sum(logcoalrates) + sum(logcoalescapes))
 }
 
+### replacement proposed for lik_coaltimes
+# to be used with original style phybreak object, ie without history host in v$inftimes or v$infectors
+# to be used with original phybreak2environment (called in logLik.phybreak)
+lik_coaltimes_new <- function(phybreakenv) {
+  if (phybreakenv$p$wh.model %in% c(1, 2, "single", "infinite")) 
+    return(0)
+  
+  if(phybreakenv$p$wh.model == "linear" && phybreakenv$p$wh.bottleneck == "wide") {
+    if(min(phybreakenv$v$inftimes) - min(phybreakenv$v$nodetimes[phybreakenv$v$nodetypes == "c"]) > 
+       phybreakenv$p$sample.mean + phybreakenv$p$wh.level/phybreakenv$p$wh.slope) return(-Inf)
+  }
+  
+  remove0nodes <- phybreakenv$v$nodetypes != "0"
+  nodetypes <- phybreakenv$v$nodetypes[remove0nodes]
+  nodehosts <- phybreakenv$v$nodehosts[remove0nodes]
+  nodetimes <- phybreakenv$v$nodetimes[remove0nodes]
+  inftimes <- c(min(phybreakenv$v$inftimes) - phybreakenv$p$sample.mean, phybreakenv$v$inftimes)
+  
+  coalnodes <- nodetypes == "c"
+  orderednodes <- order(nodehosts, nodetimes)
+  
+  coalnodes <- coalnodes[orderednodes]
+  orderedhosts <- nodehosts[orderednodes]
+  
+  bottlenecks <- sapply(0:phybreakenv$p$obs, function(i) sum((orderedhosts == i) * (1 - 2 * coalnodes))) - 1
+  dlineage <- 2 * c(FALSE, head(coalnodes, -1)) - 1
+  dlineage[!duplicated(orderedhosts)] <- bottlenecks
+  nrlineages <- 1 + cumsum(dlineage)
+  
+  whtimes <- nodetimes[orderednodes] - inftimes[orderedhosts + 1]
+  if(phybreakenv$p$hist) whtimes[orderedhosts == 0] <- whtimes[orderedhosts == 0] - min(whtimes[orderedhosts == 0])
+  whtimes[c(!duplicated(orderedhosts)[-1], FALSE)] <- 0
+  
+  logcoalrates <- switch(phybreakenv$p$wh.model, single =, infinite =,
+                         linear = -log(phybreakenv$p$wh.level + phybreakenv$p$wh.slope * whtimes[coalnodes]),
+                         exponential = 
+                           -log(phybreakenv$p$wh.level * 
+                                  exp(phybreakenv$p$wh.exponent * 
+                                        whtimes[coalnodes])),
+                         constant = -log(phybreakenv$p$wh.level) * coalnodes)
+  cumcoalrates <- switch(phybreakenv$p$wh.model, single =, infinite=,
+                         linear = log(whtimes + phybreakenv$p$wh.level/phybreakenv$p$wh.slope + 
+                                        ((whtimes + phybreakenv$p$wh.level/phybreakenv$p$wh.slope) == 0)) / phybreakenv$p$wh.slope,
+                         exponential  = -1/(phybreakenv$p$wh.level * phybreakenv$p$wh.exponent * 
+                                              exp(phybreakenv$p$wh.exponent * whtimes)),
+                         constant = whtimes/phybreakenv$p$wh.level)
+  if(phybreakenv$p$hist) {
+    logcoalrates[orderedhosts[coalnodes] == 0] <- -log(phybreakenv$p$wh.history) 
+    cumcoalrates[orderedhosts == 0] <- whtimes[orderedhosts == 0]/phybreakenv$p$wh.history
+  }
+  
+  
+  coalratediffs <- cumcoalrates - c(0, head(cumcoalrates, -1))
+  logcoalescapes <- -coalratediffs * choose(nrlineages, 2)
+  
+  return(sum(logcoalrates) + sum(logcoalescapes))
+}
+
 
 ### calculate the log-likelihood of coalescent intervals in a single host
 lik_coaltimes_host <- function(phybreakenv, hostID) {

--- a/R/mcmc-sample-minitrees.R
+++ b/R/mcmc-sample-minitrees.R
@@ -1,11 +1,21 @@
 ### functions to simulate mini-trees ###
 
-sample_coaltimes <- function(tiptimes, inftime, parameters) {
+sample_coaltimes <- function(tiptimes, inftime, parameters, historyhost = FALSE) {
   ### tests
   if(min(tiptimes) < inftime) stop("sample_coaltimes with negative tip times")
 
   ### function body
   if(length(tiptimes) < 2) return(c())
+  
+  if(historyhost) {
+    # transform times so that fixed rate 1 can be used
+    ttrans <- sort(tiptimes/parameters$wh.history, decreasing = TRUE)
+    tnodetrans <- .sctwh3(ttrans)
+    
+    res <- sort(parameters$wh.history * tnodetrans)
+    
+    return(res)
+  }
   
   switch(
     parameters$wh.model,


### PR DESCRIPTION
Hoi Bastiaan

Je had de vorige pull request nog niet geaccepteerd, dus die heb ik teruggetrokken, en er een wijziging aan toegevoegd

1. sample_coaltimes
Deze verandering zou de huidige werkzaamheid niet in de weg moeten zitten. Om hem te gebruiken, moet je een parameter wh.history in 'parameters', hebben zitten (dus in 'p' in de environment), en moet je een extra argument meegeven om te zeggen dat je coalescenttijden voor de history wil samplen (historyhost = TRUE). Dat zou je kunnen doen met 'historyhost = (host == 0)', waar je op de plek van 'host' natuurlijk de variabele zet die de dan geldende host weergeeft.

2. lik_coaltimes
Hier heb ik een alternatief voor toegevoegd (lik_coaltimes_new), omdat anders de werkzaamheid van het package als geheel verdwijnt. De nieuwe kan je gebruiken als je de andere aanpassingen aan het phybreak-object gedaan hebt (history host uit inftimes en infectors), en als er een parameter 'wh.history' in de parameterlijst staat. Ook zal de functie phybreak2environment weer terug moeten naar hoe die was. Ik hoop dat je eruit komt, maar vraag gerust als het niet lukt

Groeten
Don